### PR TITLE
build and push docker images to the GPR

### DIFF
--- a/.github/workflows/docker_gpr_cli.yml
+++ b/.github/workflows/docker_gpr_cli.yml
@@ -1,9 +1,6 @@
 name: Docker CLI
 
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   build:

--- a/.github/workflows/docker_gpr_cli.yml
+++ b/.github/workflows/docker_gpr_cli.yml
@@ -1,0 +1,25 @@
+name: Docker CLI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest 
+
+    steps:
+    - name: Copy Repo Files
+      uses: actions/checkout@master
+    - name: Publish Docker Image to GPR
+      uses: machine-learning-apps/gpr-docker-publish@master
+      with:
+        cache: true
+        IMAGE_NAME: 'pki-cli'
+        TAG: 'latest'
+        DOCKERFILE_PATH: './cli/Dockerfile'
+        BUILD_CONTEXT: './cli'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker_gpr_cli.yml
+++ b/.github/workflows/docker_gpr_cli.yml
@@ -1,6 +1,9 @@
 name: Docker CLI
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/docker_gpr_node.yml
+++ b/.github/workflows/docker_gpr_node.yml
@@ -1,6 +1,9 @@
 name: Docker Node
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/docker_gpr_node.yml
+++ b/.github/workflows/docker_gpr_node.yml
@@ -1,9 +1,6 @@
 name: Docker Node
 
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   build:

--- a/.github/workflows/docker_gpr_node.yml
+++ b/.github/workflows/docker_gpr_node.yml
@@ -1,0 +1,25 @@
+name: Docker Node
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest 
+
+    steps:
+    - name: Copy Repo Files
+      uses: actions/checkout@master
+    - name: Publish Docker Image to GPR
+      uses: machine-learning-apps/gpr-docker-publish@master
+      with:
+        cache: true
+        IMAGE_NAME: 'pki-node'
+        TAG: 'latest'
+        DOCKERFILE_PATH: './Dockerfile'
+        BUILD_CONTEXT: '.'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/W3F_TESTING.md
+++ b/W3F_TESTING.md
@@ -2,6 +2,11 @@
 
 ## Building the docker images
 
+> The docker images are also available in the
+> [Github Package Registry](https://github.com/NodleCode/PKI/packages). You
+> will want to refer to the [github documentation](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages)
+> as to how to pull them on your local machine.
+
 1. Build the `pki-node` image: `docker build -t nodle/pki-node .`
 2. Build the `pki-cli` image: `cd cli && docker build -t nodle/pki-cli .`
 


### PR DESCRIPTION
# Build and push the docker images to the GPR
Add some configuration to use Github Actions in order build and
push our `pki-{cli, node}` images to the GPR.

Fixes: #5.


## Implementation
We defined two github actions, one building `pki-node` and one
building `pki-cli`.
